### PR TITLE
Bugfix: Pass request bodies correctly

### DIFF
--- a/src/Api/Addresses.php
+++ b/src/Api/Addresses.php
@@ -4,9 +4,9 @@ namespace ComyoMedia\Shipcloud\Api;
 
 class Addresses extends Api
 {
-    public function create($parameters = [])
+    public function create($body, $parameters = [])
     {
-        return $this->post('addresses', $parameters);
+        return $this->post('addresses', $parameters, $body);
     }
 
     public function find($id)

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -24,6 +24,11 @@ abstract class Api implements ApiInterface
         return json_decode($this->execute('post', $uri, $parameters, $body)->getBody(), true);
     }
 
+    public function delete($uri = null, $parameters = [], $body = [])
+    {
+        return json_decode($this->execute('delete', $uri, $parameters, $body)->getBody(), true);
+    }
+
     public function execute($httpMethod, $uri, array $parameters = [], array $body = [])
     {
         return $this->getClient()->{$httpMethod}("{$uri}", [

--- a/src/Api/Api.php
+++ b/src/Api/Api.php
@@ -28,7 +28,7 @@ abstract class Api implements ApiInterface
     {
         return $this->getClient()->{$httpMethod}("{$uri}", [
             'query'       => $parameters,
-            'form_params' => $body
+            'json' => $body
         ]);
     }
 

--- a/src/Api/PickupRequests.php
+++ b/src/Api/PickupRequests.php
@@ -4,8 +4,8 @@ namespace ComyoMedia\Shipcloud\Api;
 
 class PickupRequests extends Api
 {
-    public function create($parameters = [])
+    public function create($body, $parameters = [])
     {
-        return $this->post('pickup_requests', $parameters);
+        return $this->post('pickup_requests', $parameters, $body);
     }
 }

--- a/src/Api/ShipmentQuotes.php
+++ b/src/Api/ShipmentQuotes.php
@@ -4,8 +4,8 @@ namespace ComyoMedia\Shipcloud\Api;
 
 class ShipmentQuotes extends Api
 {
-    public function create($parameters = [])
+    public function create($body, $parameters = [])
     {
-        return $this->post('shipment_quotes', $parameters);
+        return $this->post('shipment_quotes', $parameters, $body);
     }
 }

--- a/src/Api/Shipments.php
+++ b/src/Api/Shipments.php
@@ -4,9 +4,9 @@ namespace ComyoMedia\Shipcloud\Api;
 
 class Shipments extends Api
 {
-    public function create($parameters = [])
+    public function create($body, $parameters = [])
     {
-        return $this->post('shipments', $parameters);
+        return $this->post('shipments', $parameters, $body);
     }
 
     public function find($id)

--- a/src/Api/Shipments.php
+++ b/src/Api/Shipments.php
@@ -14,6 +14,11 @@ class Shipments extends Api
         return $this->get("shipments/{$id}");
     }
 
+    public function delete($id)
+    {
+        return $this->delete("shipments/{$id}");
+    }
+
     public function all($parameters = [])
     {
         return $this->get('shipments', $parameters);


### PR DESCRIPTION
Request bodies are now correctly passed to the create functions and added to the request as json in the execute function
