### PR TITLE
fix type annotations of Client->send() method

### DIFF
--- a/src/Http/Client.php
+++ b/src/Http/Client.php
@@ -6,6 +6,7 @@ use GuzzleHttp\Query;
 use GuzzleHttp\Event\BeforeEvent;
 use GuzzleHttp\Exception\ClientException;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 class Client extends \GuzzleHttp\Client implements ClientInterface
 {
@@ -24,7 +25,7 @@ class Client extends \GuzzleHttp\Client implements ClientInterface
         ]);
     }
 
-    public function send(RequestInterface $request, array $options = [])
+    public function send(RequestInterface $request, array $options = []): ResponseInterface
     {
         return parent::send($request, $options);
     }


### PR DESCRIPTION
The upstream Guzzle ClientInterface definition requires
the send() method to return a ResponseInterface type, see
https://github.com/guzzle/guzzle/blob/ca5c743d20730d1a129a9ee04cbe854df7304b96/src/ClientInterface.php#L30

The related commit was merged to guzzle in 2019:
https://github.com/guzzle/guzzle/commit/3d9079b5c3b12f54ea6cb857473bd90b21a6fd86